### PR TITLE
Remove has_rdoc option because it is deprecated.

### DIFF
--- a/joule.gemspec
+++ b/joule.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*"] + ["README.rdoc", "Rakefile"]
   s.extra_rdoc_files = ["README.rdoc"]
 
-  s.has_rdoc = true
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Joule", "--main", "README.rdoc"]
 
   s.rubygems_version = "1.3.4"


### PR DESCRIPTION
and gives this annoying message everytime I install:

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/jibrank/.rvm/gems/ruby-2.6.9/bundler/gems/joule-4a67fd0972ef/joule.gemspec:21.
```